### PR TITLE
fix(minio): fix minio with tmpfs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up PDM
         uses: pdm-project/setup-pdm@v2
       - name: Cache dependencies
@@ -23,7 +24,7 @@ jobs:
       - name: Run commit-lint
         env:
           FROM_REF: origin/${{ github.base_ref }}
-          TO_REF: origin/${{ github.head_ref }}
+          TO_REF: HEAD
         run: pdm ci-commit-lint
 
   lint:
@@ -33,6 +34,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up PDM
         uses: pdm-project/setup-pdm@v2
       - name: Cache dependencies
@@ -49,7 +51,7 @@ jobs:
       - name: Run lint
         env:
           FROM_REF: origin/${{ github.base_ref }}
-          TO_REF: origin/${{ github.head_ref }}
+          TO_REF: HEAD
         run: pdm ci-lint
 
   test:

--- a/testcontainers_on_whales/minio.py
+++ b/testcontainers_on_whales/minio.py
@@ -22,7 +22,7 @@ class MinioContainer(Container):
             image=image,
             command=[
                 "server",
-                "/tmp/storage",
+                "/data",
                 "--console-address",
                 f":{MinioContainer.MINIO_CONSOLE_PORT}",
             ],


### PR DESCRIPTION
The latest images of MinIO do not seem to work as before when using tmpfs / `/tmp/` as storage.
minio container now uses `/data`, as suggested in the official docker image documentation.